### PR TITLE
Fix Query invalidation issues (stale data)

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,7 +7,13 @@ import { routeTree } from "./routeTree.gen";
 
 // Create a new router instance
 export const getRouter = () => {
-	const queryClient = new QueryClient();
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				refetchOnMount: "always",
+			},
+		},
+	});
 
 	const router = createRouter({
 		routeTree,


### PR DESCRIPTION
# Description

Fixes two invalidation issues. Due to SSE (Server-Sent Events), staletime is set to infinity to avoid background updates, relying on SSE for hydration.

- On page navigation (mount), data is not invalidated. This has been fixed
- Refetching on window focus only applies when data is stale. Manual handling has been added to mark everything as invalid upon window refocus (i.e. closing PWA and opening it again)